### PR TITLE
fix: CI test failure in test-claude-code-emacs-execute-custom-command-unified

### DIFF
--- a/test-claude-code-emacs-commands.el
+++ b/test-claude-code-emacs-commands.el
@@ -280,9 +280,13 @@
                ;; Mock the global command files
                ((symbol-function 'claude-code-emacs-list-global-command-files)
                 (lambda () '("commit-push.md")))
-               ;; Mock reading global command content
-               ((symbol-function 'claude-code-emacs-read-global-command-file)
-                (lambda (file) "user command content")))
+               ;; Mock reading command file - mock the general function used by execute-custom-command
+               ((symbol-function 'claude-code-emacs-read-command-file)
+                (lambda (filepath) 
+                  (cond
+                   ((string-match-p "test-project\\.md$" filepath) "project command content")
+                   ((string-match-p "commit-push\\.md$" filepath) "user command content")
+                   (t nil)))))
 
        ;; Test project command
        (claude-code-emacs-execute-custom-command)


### PR DESCRIPTION
Fixes #1

This PR fixes the failing CI test `test-claude-code-emacs-execute-custom-command-unified`.

## Problem
The test was mocking `claude-code-emacs-read-global-command-file` but the actual implementation uses `claude-code-emacs-read-command-file` with the full filepath. This caused the test to fail because it tried to read a non-existent file from the filesystem.

## Solution
Updated the test to mock the correct function (`claude-code-emacs-read-command-file`) that is actually called by `claude-code-emacs-execute-custom-command`.

Generated with [Claude Code](https://claude.ai/code)