### PR TITLE
fix: Better error message if outside project.

### DIFF
--- a/claude-code-core-test.el
+++ b/claude-code-core-test.el
@@ -186,5 +186,9 @@
             (should (string-match-p session-id vterm-shell-value)))
         (kill-buffer test-buffer)))))
 
+(ert-deftest test-claude-code-normalize-project-root ()
+  (should (equal "/foo/bar/baz" (claude-code-normalize-project-root "/foo/bar/baz/")))
+  (should-error (claude-code-normalize-project-root nil) :type 'error))
+
 (provide 'test-claude-code-core)
 ;;; test-claude-code-core.el ends here

--- a/claude-code-core.el
+++ b/claude-code-core.el
@@ -67,8 +67,9 @@
 
 (defun claude-code-normalize-project-root (project-root)
   "Normalize PROJECT-ROOT by removing trailing slash."
-  (directory-file-name project-root))
-
+  (if project-root
+      (directory-file-name project-root)
+    (error "Current directory is not part of a project")))
 (defun claude-code-buffer-name ()
   "Return the buffer name for Claude Code session in current project."
   (let ((project-root (claude-code-normalize-project-root (projectile-project-root))))


### PR DESCRIPTION
Before: starting Claude outside any project gave:
  Lisp error: (wrong-type-argument stringp nil)

Now it returns:
  Current directory is not part of a project