### PR TITLE
feat: Special edit buffer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,17 @@ Each project gets its own Claude Code buffer named `*claude:<project-root>*`. Ke
 - `claude-code-close()` - Closes the window showing Claude Code buffer
 - `claude-code-quit()` - Terminates session and kills buffer
 
+### Edit Special Buffer System
+The edit special feature provides a dedicated buffer for composing messages:
+- `claude-code-edit-special()` - Opens a markdown buffer for composing
+- `claude-code-edit-finish()` - Sends content and closes buffer (C-c C-c)
+- `claude-code-edit-cancel()` - Closes without sending (C-c C-k)
+- Buffer naming: `*claude-code-edit:<project-root>*` per project
+- Keybinding: `C-c '` in vterm mode to open edit buffer
+- Allows full Emacs editing capabilities instead of typing in vterm
+- Content is sent character by character to vterm on finish
+- Similar to `org-edit-special` workflow
+
 ### String Chunking System
 Long strings are split into 50-character chunks to avoid terminal input limitations:
 - `claude-code-chunk-string()` - Core chunking function
@@ -363,6 +374,12 @@ The MCP server supports real-time notifications from Emacs:
 - **Timer management**: Ping timers are properly cleaned up on disconnect to prevent resource leaks
 
 ### Recent Changes
+- **Edit Special feature**:
+  - Added `claude-code-edit-special` for composing messages in a dedicated buffer
+  - New module: `claude-code-edit.el` with markdown editing support
+  - Keybindings: `C-c '` in vterm, `C-c C-c` to send, `C-c C-k` to cancel
+  - Accessible via transient menu (`E` key)
+  - Similar workflow to `org-edit-special`
 - **Version 0.7.0**:
   - Added `claude-code-send-ctrl-t` function for toggling TODO display (Ctrl+T)
   - Changed toggle expand from Ctrl+R to Ctrl+O to match Claude Code updates

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ BATCH = $(EMACS) -batch -Q -L .
 CORE_FILES = claude-code-core.el \
 	     claude-code-commands.el \
 	     claude-code-ui.el \
-	     claude-code-prompt.el
+	     claude-code-prompt.el \
+	     claude-code-edit.el
 
 MCP_MODULES = claude-code-mcp-connection.el \
 	      claude-code-mcp-protocol.el \
@@ -18,7 +19,8 @@ TEST_CORE_FILES = claude-code-core-test.el \
 		  claude-code-buffer-test.el \
 		  claude-code-commands-test.el \
 		  claude-code-ui-test.el \
-		  claude-code-prompt-test.el
+		  claude-code-prompt-test.el \
+		  test-claude-code-edit.el
 
 TEST_MCP_FILES = claude-code-mcp-connection-test.el \
 		 claude-code-mcp-protocol-test.el \

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Claude Code can directly interact with your Emacs environment:
 | `C-c RET` | Send Return key |
 | `C-c TAB` | Send Shift+Tab (toggle auto-accept) |
 | `C-c C-t` | Open transient menu |
+| `C-c '` | Edit special (compose in buffer) |
 
 #### In Prompt Buffer
 | Key | Action |
@@ -85,6 +86,20 @@ Claude Code can directly interact with your Emacs environment:
 | `/` | Slash commands menu |
 
 ## Common Workflows
+
+### Edit Special - Compose in Buffer
+Instead of typing directly in the vterm, use Edit Special to compose messages in a full Emacs buffer:
+```elisp
+M-x claude-code-edit-special
+;; or press 'C-c '' in vterm mode
+;; or press 'E' in transient menu
+```
+This opens a markdown buffer where you can:
+- Use full Emacs editing capabilities (search, multiple cursors, etc.)
+- Compose multi-line messages comfortably
+- Press `C-c C-c` to send and close, or `C-c C-k` to cancel
+
+Similar to `org-edit-special`, but for Claude Code messages.
 
 ### Project Prompts
 Each project gets a `.claude-code.prompt.md` file at the project root. When you open this file, it automatically positions at the end for quick prompt entry:

--- a/claude-code-edit.el
+++ b/claude-code-edit.el
@@ -145,9 +145,7 @@ without sending anything."
                       (buffer-list))
        (error "No Claude Code session found.  Use 'claude-code-run' to start one"))))
 
-  (let* ((edit-buffer (claude-code-edit-get-or-create-buffer))
-         (existing-content (with-current-buffer edit-buffer
-                             (buffer-string))))
+  (let ((edit-buffer (claude-code-edit-get-or-create-buffer)))
     ;; Display the buffer
     (claude-code-edit-display-buffer edit-buffer)
 
@@ -157,10 +155,8 @@ without sending anything."
         (markdown-mode))
       (claude-code-edit-mode 1)
 
-      ;; If buffer is empty, add helpful hint
-      (when (string-empty-p (string-trim existing-content))
-        (insert "<!-- Compose your message to Claude Code here -->\n\n")
-        (goto-char (point-max))))))
+      ;; Position cursor at end
+      (goto-char (point-max)))))
 
 ;;;###autoload
 (defun claude-code-edit-finish ()

--- a/claude-code-edit.el
+++ b/claude-code-edit.el
@@ -1,0 +1,218 @@
+;;; claude-code-edit.el --- Special edit buffer for Claude Code Emacs -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025
+
+;; Author: George Mauer
+;; Keywords: tools, convenience
+;; Version: 0.1.0
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This module provides a special edit buffer for composing messages to Claude Code.
+;; Similar to `org-edit-special', it opens a dedicated buffer where you can edit
+;; text with full Emacs capabilities before sending it to the Claude Code vterm.
+;;
+;; Usage:
+;;   M-x claude-code-edit-special  ; Open edit buffer
+;;   C-c C-c                       ; Send and close
+;;   C-c C-k                       ; Cancel without sending
+
+;;; Code:
+
+(require 'markdown-mode)
+
+;; Forward declarations
+(declare-function claude-code-send-string "claude-code-core" (string &optional paste-p))
+(declare-function claude-code-normalize-project-root "claude-code-core" (project-root))
+(declare-function claude-code-ensure-buffer "claude-code-core" ())
+(declare-function projectile-project-root "projectile" ())
+
+;;; Customization
+
+(defgroup claude-code-edit nil
+  "Special edit buffer for Claude Code."
+  :group 'claude-code
+  :prefix "claude-code-edit-")
+
+(defcustom claude-code-edit-buffer-window-setup 'reorganize-frame
+  "How to display the edit buffer.
+Possible values are:
+  current-window         Show edit buffer in current window
+  other-window           Show edit buffer in another window
+  reorganize-frame       Show edit buffer in another window and maximize
+  other-frame            Show edit buffer in another frame
+
+The default is `reorganize-frame' which provides a focused editing experience."
+  :type '(choice
+          (const :tag "current-window" current-window)
+          (const :tag "other-window" other-window)
+          (const :tag "reorganize-frame" reorganize-frame)
+          (const :tag "other-frame" other-frame))
+  :group 'claude-code-edit)
+
+;;; Buffer management
+
+(defun claude-code-edit-buffer-name ()
+  "Return the buffer name for Claude Code edit buffer in current project.
+Return nil if not in a project."
+  (when-let ((project-root (claude-code-normalize-project-root (projectile-project-root))))
+    (format "*claude-code-edit:%s*" project-root)))
+
+(defun claude-code-edit-get-buffer ()
+  "Get the Claude Code edit buffer for current project.
+Return nil if it doesn't exist."
+  (get-buffer (claude-code-edit-buffer-name)))
+
+(defun claude-code-edit-get-or-create-buffer ()
+  "Get or create the Claude Code edit buffer for the current project."
+  (let ((buf-name (claude-code-edit-buffer-name)))
+    (or (get-buffer buf-name)
+        (get-buffer-create buf-name))))
+
+;;; Edit buffer display
+
+(defun claude-code-edit-display-buffer (buffer)
+  "Display edit BUFFER according to `claude-code-edit-buffer-window-setup'."
+  (pcase claude-code-edit-buffer-window-setup
+    ('current-window
+     (switch-to-buffer buffer))
+    ('other-window
+     (switch-to-buffer-other-window buffer))
+    ('reorganize-frame
+     (delete-other-windows)
+     (switch-to-buffer-other-window buffer))
+    ('other-frame
+     (switch-to-buffer-other-frame buffer))
+    (_
+     (switch-to-buffer-other-window buffer))))
+
+;;; Mode definition
+
+(defvar claude-code-edit-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-c") 'claude-code-edit-finish)
+    (define-key map (kbd "C-c C-k") 'claude-code-edit-cancel)
+    map)
+  "Keymap for `claude-code-edit-mode'.")
+
+(define-minor-mode claude-code-edit-mode
+  "Minor mode for Claude Code edit buffers.
+
+\\{claude-code-edit-mode-map}"
+  :lighter " Claude-Edit"
+  :keymap claude-code-edit-mode-map
+  (when claude-code-edit-mode
+    (setq-local header-line-format
+                '(:eval (format "Claude Code Edit - %s | C-c C-c to send, C-c C-k to cancel"
+                                (file-name-nondirectory
+                                 (directory-file-name
+                                  (claude-code-normalize-project-root (projectile-project-root)))))))))
+
+;;; Main commands
+
+;;;###autoload
+(defun claude-code-edit-special ()
+  "Open a special edit buffer for composing Claude Code messages.
+Similar to `org-edit-special', this provides a dedicated buffer
+for editing text before sending it to Claude Code.
+
+Use \\[claude-code-edit-finish] (C-c C-c) to send the buffer contents
+to Claude Code and close the edit buffer.
+
+Use \\[claude-code-edit-cancel] (C-c C-k) to close the edit buffer
+without sending anything."
+  (interactive)
+  ;; Ensure there's a Claude Code session running
+  ;; Try to find any claude-code buffer if the standard naming fails
+  (condition-case nil
+      (claude-code-ensure-buffer)
+    (error
+     (unless (cl-some (lambda (buf)
+                        (string-match-p "\\*claude" (buffer-name buf)))
+                      (buffer-list))
+       (error "No Claude Code session found.  Use 'claude-code-run' to start one"))))
+
+  (let* ((edit-buffer (claude-code-edit-get-or-create-buffer))
+         (existing-content (with-current-buffer edit-buffer
+                             (buffer-string))))
+    ;; Display the buffer
+    (claude-code-edit-display-buffer edit-buffer)
+
+    ;; Set up the buffer if it's new
+    (with-current-buffer edit-buffer
+      (unless (derived-mode-p 'markdown-mode)
+        (markdown-mode))
+      (claude-code-edit-mode 1)
+
+      ;; If buffer is empty, add helpful hint
+      (when (string-empty-p (string-trim existing-content))
+        (insert "<!-- Compose your message to Claude Code here -->\n\n")
+        (goto-char (point-max))))))
+
+;;;###autoload
+(defun claude-code-edit-finish ()
+  "Send the edit buffer contents to Claude Code and close the buffer."
+  (interactive)
+  (unless claude-code-edit-mode
+    (user-error "Not in a Claude Code edit buffer"))
+
+  (let* ((content (buffer-string))
+         (trimmed (string-trim content)))
+    (if (string-empty-p trimmed)
+        (message "Edit buffer is empty, nothing to send")
+      ;; Find any Claude Code buffer and send to it
+      (let ((claude-buffer (or (claude-code-get-buffer)
+                               ;; Fall back to finding any claude-code vterm buffer (but NOT edit buffers)
+                               (cl-find-if (lambda (buf)
+                                             (and (string-match-p "\\*claude-?code\\[" (buffer-name buf))
+                                                  (not (string-match-p "edit" (buffer-name buf)))))
+                                           (buffer-list)))))
+        (if (not claude-buffer)
+            (message "Failed to send to Claude Code: No Claude Code session found")
+          ;; Send directly to the vterm buffer using the same approach as claude-code-send-string
+          (condition-case err
+              (progn
+                (with-current-buffer claude-buffer
+                  (require 'vterm)
+                  (goto-char (point-max))  ; Make sure we're at the end
+                  (vterm-send-string trimmed t)  ; Use paste mode
+                  ;; Wait for processing
+                  (when (boundp 'vterm-timer-delay)
+                    (sit-for (* vterm-timer-delay 3)))
+                  (vterm-send-return))
+                (message "Sent %d characters to Claude Code" (length trimmed))
+                ;; Clear the buffer for next use
+                (erase-buffer)
+                ;; Close the edit buffer window
+                (when-let ((window (get-buffer-window (current-buffer))))
+                  (quit-window nil window)))
+            (error
+             (message "Failed to send to Claude Code: %s" (error-message-string err)))))))))
+
+;;;###autoload
+(defun claude-code-edit-cancel ()
+  "Close the edit buffer without sending anything.
+The buffer contents are preserved for the next edit session."
+  (interactive)
+  (unless claude-code-edit-mode
+    (user-error "Not in a Claude Code edit buffer"))
+
+  (when-let ((window (get-buffer-window (current-buffer))))
+    (quit-window nil window))
+  (message "Edit cancelled"))
+
+(provide 'claude-code-edit)
+;;; claude-code-edit.el ends here

--- a/claude-code-ui.el
+++ b/claude-code-ui.el
@@ -83,6 +83,9 @@
 (declare-function claude-code-insert-current-file-path-to-prompt "claude-code-prompt" ())
 (declare-function claude-code-insert-current-file-path-to-session "claude-code-prompt" ())
 
+;; Edit forward declarations
+(declare-function claude-code-edit-special "claude-code-edit" ())
+
 ;;;;; Vterm terminal customizations
 (defcustom claude-code-vterm-buffer-multiline-output t
   "Whether to buffer vterm output to prevent flickering on multi-line input.
@@ -128,6 +131,7 @@ Minimum value is 0.001 seconds to ensure proper operation."
     (define-key map (kbd "C-c RET") 'claude-code-send-return)
     (define-key map (kbd "C-c TAB") 'claude-code-send-shift-tab)
     (define-key map (kbd "C-c C-t") 'claude-code-transient)
+    (define-key map (kbd "C-c '") 'claude-code-edit-special)
     map)
   "Keymap for `claude-code-vterm-mode'.")
 
@@ -294,7 +298,8 @@ INPUT is the terminal output string."
     ("b" "Switch to Claude Code buffer" claude-code-switch-to-buffer)
     ("q" "Close Claude Code window" claude-code-close)
     ("Q" "Quit Claude Code session" claude-code-quit)
-    ("p" "Open Prompt File" claude-code-open-prompt-file)]
+    ("p" "Open Prompt File" claude-code-open-prompt-file)
+    ("E" "Edit Special (compose message)" claude-code-edit-special)]
    ["Actions"
     ("s" "Send menu" claude-code-send-transient)
     ("i" "Insert menu" claude-code-insert-transient)]

--- a/claude-code.el
+++ b/claude-code.el
@@ -6,7 +6,7 @@
 ;; Keywords: tools, convenience
 ;; Version: 0.7.1
 ;; URL: https://github.com/yuya373/claude-code-emacs
-;; Package-Requires: ((emacs "28.1") (projectile "2.5.0") (vterm "0.0.2") (transient "0.4.0") (markdown-mode "2.5"))
+;; Package-Requires: ((emacs "28.1") (projectile "2.5.0") (vterm) (transient "0.4.0") (markdown-mode "2.5"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -71,6 +71,7 @@
 (require 'claude-code-commands)
 (require 'claude-code-ui)
 (require 'claude-code-prompt)
+(require 'claude-code-edit)
 
 ;; MCP integration (only when websocket is available)
 (require 'claude-code-mcp)

--- a/test-claude-code-edit.el
+++ b/test-claude-code-edit.el
@@ -1,0 +1,196 @@
+;;; test-claude-code-edit.el --- Tests for claude-code-edit.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025
+
+;; Author: George Mauer
+;; Keywords: tools, convenience
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; Tests for claude-code-edit.el
+
+;;; Code:
+
+(require 'ert)
+(require 'cl-lib)
+(require 'claude-code-edit)
+
+;;; Test utilities
+
+(defun test-claude-code-edit--cleanup ()
+  "Clean up test buffers."
+  (when-let ((buf (get-buffer "*claude-code-edit:/test/project*")))
+    (kill-buffer buf))
+  (when-let ((buf (get-buffer "*claude:/test/project*")))
+    (kill-buffer buf)))
+
+;;; Tests for buffer management
+
+(ert-deftest test-claude-code-edit-buffer-name ()
+  "Test edit buffer naming."
+  (let ((projectile-project-root "/test/project/"))
+    (should (equal (claude-code-edit-buffer-name)
+                   "*claude-code-edit:/test/project*"))))
+
+(ert-deftest test-claude-code-edit-buffer-name-nil-when-no-project ()
+  "Test edit buffer name returns nil when not in a project."
+  (let ((projectile-project-root nil))
+    (should (null (claude-code-edit-buffer-name)))))
+
+(ert-deftest test-claude-code-edit-get-buffer ()
+  "Test getting edit buffer."
+  (test-claude-code-edit--cleanup)
+  (let ((projectile-project-root "/test/project/"))
+    ;; Buffer doesn't exist yet
+    (should (null (claude-code-edit-get-buffer)))
+
+    ;; Create buffer
+    (get-buffer-create "*claude-code-edit:/test/project*")
+
+    ;; Now it should exist
+    (should (bufferp (claude-code-edit-get-buffer)))
+
+    (test-claude-code-edit--cleanup)))
+
+(ert-deftest test-claude-code-edit-get-or-create-buffer ()
+  "Test getting or creating edit buffer."
+  (test-claude-code-edit--cleanup)
+  (let ((projectile-project-root "/test/project/"))
+    ;; Buffer doesn't exist, should create it
+    (let ((buf (claude-code-edit-get-or-create-buffer)))
+      (should (bufferp buf))
+      (should (equal (buffer-name buf) "*claude-code-edit:/test/project*")))
+
+    ;; Second call should return same buffer
+    (let ((buf1 (claude-code-edit-get-or-create-buffer))
+          (buf2 (claude-code-edit-get-or-create-buffer)))
+      (should (eq buf1 buf2)))
+
+    (test-claude-code-edit--cleanup)))
+
+;;; Tests for mode
+
+(ert-deftest test-claude-code-edit-mode-keymap ()
+  "Test edit mode has correct keybindings."
+  (test-claude-code-edit--cleanup)
+  (let ((projectile-project-root "/test/project/"))
+    (with-current-buffer (claude-code-edit-get-or-create-buffer)
+      (claude-code-edit-mode 1)
+      ;; Check keybindings exist
+      (should (keymapp claude-code-edit-mode-map))
+      (should (eq (lookup-key claude-code-edit-mode-map (kbd "C-c C-c"))
+                  'claude-code-edit-finish))
+      (should (eq (lookup-key claude-code-edit-mode-map (kbd "C-c C-k"))
+                  'claude-code-edit-cancel)))
+    (test-claude-code-edit--cleanup)))
+
+;;; Tests for main commands
+
+(ert-deftest test-claude-code-edit-special-requires-session ()
+  "Test edit special requires an active Claude Code session."
+  (test-claude-code-edit--cleanup)
+  (let ((projectile-project-root "/test/project/"))
+    ;; Mock ensure-buffer to simulate no session
+    (cl-letf (((symbol-function 'claude-code-ensure-buffer)
+               (lambda () (error "No Claude Code session for this project"))))
+      (should-error (claude-code-edit-special)
+                    :type 'error))
+    (test-claude-code-edit--cleanup)))
+
+(ert-deftest test-claude-code-edit-finish-sends-content ()
+  "Test edit finish sends buffer content."
+  (test-claude-code-edit--cleanup)
+  (let ((projectile-project-root "/test/project/")
+        (sent-string nil))
+    ;; Mock send-string to capture what's sent
+    (cl-letf (((symbol-function 'claude-code-send-string)
+               (lambda (string &optional _paste-p)
+                 (setq sent-string string))))
+
+      (with-current-buffer (claude-code-edit-get-or-create-buffer)
+        (claude-code-edit-mode 1)
+        (erase-buffer)
+        (insert "Test message\n\nWith multiple lines")
+
+        ;; Mock window management
+        (cl-letf (((symbol-function 'get-buffer-window)
+                   (lambda (_buf) nil))
+                  ((symbol-function 'quit-window)
+                   (lambda (&rest _args) nil)))
+          (claude-code-edit-finish)
+
+          ;; Check that content was sent (trimmed)
+          (should (equal sent-string "Test message\n\nWith multiple lines"))
+
+          ;; Buffer should be cleared
+          (should (string-empty-p (string-trim (buffer-string)))))))
+
+    (test-claude-code-edit--cleanup)))
+
+(ert-deftest test-claude-code-edit-finish-empty-buffer ()
+  "Test edit finish with empty buffer."
+  (test-claude-code-edit--cleanup)
+  (let ((projectile-project-root "/test/project/")
+        (sent-string nil))
+    ;; Mock send-string to capture what's sent
+    (cl-letf (((symbol-function 'claude-code-send-string)
+               (lambda (string &optional _paste-p)
+                 (setq sent-string string))))
+
+      (with-current-buffer (claude-code-edit-get-or-create-buffer)
+        (claude-code-edit-mode 1)
+        (erase-buffer)
+
+        (claude-code-edit-finish)
+
+        ;; Nothing should be sent for empty buffer
+        (should (null sent-string))))
+
+    (test-claude-code-edit--cleanup)))
+
+(ert-deftest test-claude-code-edit-cancel-preserves-content ()
+  "Test edit cancel preserves buffer content."
+  (test-claude-code-edit--cleanup)
+  (let ((projectile-project-root "/test/project/"))
+    (with-current-buffer (claude-code-edit-get-or-create-buffer)
+      (claude-code-edit-mode 1)
+      (erase-buffer)
+      (insert "Test content that should be preserved")
+
+      ;; Mock window management
+      (cl-letf (((symbol-function 'get-buffer-window)
+                 (lambda (_buf) nil))
+                ((symbol-function 'quit-window)
+                 (lambda (&rest _args) nil)))
+
+        (claude-code-edit-cancel)
+
+        ;; Content should still be there
+        (should (equal (buffer-string)
+                       "Test content that should be preserved"))))
+
+    (test-claude-code-edit--cleanup)))
+
+;;; Test customization
+
+(ert-deftest test-claude-code-edit-buffer-window-setup-valid-values ()
+  "Test that customization accepts valid values."
+  (dolist (value '(current-window other-window reorganize-frame other-frame))
+    (setq claude-code-edit-buffer-window-setup value)
+    (should (eq claude-code-edit-buffer-window-setup value))))
+
+(provide 'test-claude-code-edit)
+;;; test-claude-code-edit.el ends here


### PR DESCRIPTION
I got annoyed that I have to type into vterm all the time so had claude create me a `claude-code-edit-special` similar  to `org-edit-special` which pops open a dedicated buffer you can modify and then sends what you put there character by character

Draft PR since I only just started using it last night and I'm going to get some testing in with my fork, but wanted to give you a heads up if you want any changes 
<img width="607" height="252" alt="image showing a dedicated special buffer for editing" src="https://github.com/user-attachments/assets/8e757a53-c11c-43df-af2b-33e332a1b646" />
