### PR TITLE
fix: use date-based version for vterm in Package-Requires

### DIFF
--- a/claude-code.el
+++ b/claude-code.el
@@ -6,7 +6,7 @@
 ;; Keywords: tools, convenience
 ;; Version: 0.8.1
 ;; URL: https://github.com/yuya373/claude-code-emacs
-;; Package-Requires: ((emacs "28.1") (projectile "2.5.0") (vterm "0.0.2") (transient "0.4.0") (markdown-mode "2.5"))
+;; Package-Requires: ((emacs "28.1") (projectile "2.5.0") (vterm "20241218") (transient "0.4.0") (markdown-mode "2.5"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
## Summary

Fixes #9 — the `Package-Requires' header listed `(vterm "0.0.2")', which doesn't match vterm's actual versioning scheme on MELPA. vterm uses date-based versions like `20260406.134', so the specifier looked broken to users inspecting the manifest.

In practice it still worked (numeric comparison: `0.0.2 < 20260406'), but it caused confusion and led people to remove the constraint entirely.

## Changes

- `claude-code.el`: `(vterm "0.0.2")` → `(vterm "20241218")`
  - Matches MELPA's date-based versioning
  - Recent enough to reflect a known-tested vterm version (CI installs `vterm-20260406.134`, my local is `vterm-20241218.331`)
  - Loose enough to accept the vast majority of installed vterm versions

## Test plan

- [x] `make compile` — no warnings
- [x] `make test` — 105 pass / 1 skipped (unrelated lsp test)
- [ ] CI green on Emacs 28.1 / 29.1 / snapshot

🤖 Generated with [Claude Code](https://claude.com/claude-code)