### PR TITLE
ci: activate npm@latest via corepack to fix release publish

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,8 +21,16 @@ jobs:
       with:
         node-version: '22'
 
-    - name: Install latest npm (for OIDC trusted publishing)
-      run: npm install -g npm@latest
+    - name: Activate npm@latest via corepack
+      # `npm install -g npm@latest` is unreliable: it has npm overwrite its
+      # own modules mid-run, which can crash with "Cannot find module
+      # 'promise-retry'" when the bundled npm and the new one disagree on
+      # tree shape. corepack swaps the active manager atomically and avoids
+      # the self-overwrite hazard.
+      run: |
+        corepack enable
+        corepack prepare npm@latest --activate
+        npm --version
 
     - name: Configure npm registry
       run: npm config set registry https://registry.npmjs.org/


### PR DESCRIPTION
## Summary

The v0.8.2 release publish workflow failed at the `Install latest npm (for OIDC trusted publishing)` step:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`

This is a known hazard of `npm install -g npm@latest`: npm rewrites its own files mid-execution, and when the bundled npm and the upgrade target disagree on internal tree shape, the in-flight process can no longer resolve its own modules.

## Fix

Use `corepack prepare npm@latest --activate` instead. corepack ships with Node.js 16.9+ and atomically swaps the active package manager without making npm rewrite itself, so we still get the up-to-date npm needed for OIDC trusted publishing — without the self-overwrite race.

## Test plan

- [ ] Merge this PR
- [ ] Re-run the failed `Publish Release` workflow on tag v0.8.2 (`gh run rerun 25457534513` after merge), or re-publish the release to retrigger
- [ ] Verify npm registry has `claude-code-emacs-mcp@0.8.2`
- [ ] Verify MELPA recipe artifact uploaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)