### PR TITLE
ci: pin npm to 11.6.0 via corepack for OIDC publishing

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,15 +21,17 @@ jobs:
       with:
         node-version: '22'
 
-    - name: Activate npm@latest via corepack
-      # `npm install -g npm@latest` is unreliable: it has npm overwrite its
-      # own modules mid-run, which can crash with "Cannot find module
-      # 'promise-retry'" when the bundled npm and the new one disagree on
-      # tree shape. corepack swaps the active manager atomically and avoids
-      # the self-overwrite hazard.
+    - name: Activate npm 11 via corepack (required for OIDC publishing)
+      # OIDC trusted publishing needs npm >= 11.5.1.
+      # We don't use `npm install -g npm@latest` because it has npm overwrite
+      # its own modules mid-run and can crash with "Cannot find module
+      # 'promise-retry'".
+      # We don't use `corepack prepare npm@latest` because the `latest` tag
+      # resolved through corepack on this runner returned npm 10.9.7, which
+      # is too old for OIDC. Pin to an explicit OIDC-capable version instead.
       run: |
         corepack enable
-        corepack prepare npm@latest --activate
+        corepack prepare npm@11.6.0 --activate
         npm --version
 
     - name: Configure npm registry


### PR DESCRIPTION
## Summary

The v0.8.3 release publish workflow failed with `ENEEDAUTH` at the npm publish step. Root cause: `corepack prepare npm@latest --activate` resolved to npm **10.9.7** (the same version setup-node bundles), which is too old for OIDC trusted publishing — that needs npm >= 11.5.1.

## Fix

Pin to npm 11.6.0 explicitly:

\`\`\`yaml
corepack prepare npm@11.6.0 --activate
\`\`\`

This sidesteps corepack's stale `latest` metadata and guarantees an OIDC-capable npm.

## Test plan

- [ ] Merge this PR
- [ ] Cut v0.8.4 (the v0.8.3 tag pins to a commit before this fix, so we can't reuse it)
- [ ] Verify npm 11.6.0 logs in the workflow
- [ ] Verify `claude-code-mcp-server@0.8.4` lands on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)