### PR TITLE
fix: resolve Claude buffer name in process buffer in vterm filter (#17)

### DIFF
--- a/claude-code-ui-test.el
+++ b/claude-code-ui-test.el
@@ -231,6 +231,41 @@ cursor to be shown there."
           (should (string-match "Error in vterm filter:" error-message))
           (should (string-match "Test error" error-message)))))))
 
+(ert-deftest test-claude-code--vterm-multiline-buffer-filter-ambient-buffer-not-in-project ()
+  "Test filter resolves the buffer name against the process buffer.
+Regression test for issue #17: a process filter runs with whatever buffer
+happened to be current when output arrived.  When that ambient buffer is
+outside a projectile project, resolving `claude-code-buffer-name' against
+it signals a `user-error', flooding *Messages*.  The filter must resolve
+the name relative to the process buffer instead."
+  (let ((orig-fun-called nil)
+        (proc-buffer (get-buffer-create "*claude:/project*"))
+        (ambient-buffer (get-buffer-create "*not-a-project*"))
+        (test-process 'mock-process))
+    (unwind-protect
+        (let ((claude-code-vterm-buffer-multiline-output t))
+          (cl-letf (((symbol-function 'process-buffer) (lambda (_) proc-buffer))
+                    ;; Simulate projectile: only the process buffer's
+                    ;; default-directory resolves to a project; the ambient
+                    ;; buffer signals via `claude-code-normalize-project-root'.
+                    ((symbol-function 'claude-code-buffer-name)
+                     (lambda ()
+                       (if (eq (current-buffer) proc-buffer)
+                           "*claude:/project*"
+                         (user-error "Current directory is not part of a project")))))
+            ;; Run the filter from the ambient (non-project) buffer.
+            (with-current-buffer ambient-buffer
+              (claude-code--vterm-multiline-buffer-filter
+               (lambda (_proc _input)
+                 (setq orig-fun-called t))
+               test-process
+               "simple text"))
+            ;; The filter must not have signaled, and should have passed
+            ;; the input through since this is the Claude process buffer.
+            (should orig-fun-called)))
+      (kill-buffer proc-buffer)
+      (kill-buffer ambient-buffer))))
+
 ;;; Tests for transient menus
 
 (ert-deftest test-claude-code-transient-defined ()

--- a/claude-code-ui.el
+++ b/claude-code-ui.el
@@ -164,9 +164,19 @@ indicate cursor positioning and line clearing operations.
 ORIG-FUN is the original vterm--filter function.
 PROCESS is the vterm process.
 INPUT is the terminal output string."
+  ;; NOTE: A process filter runs with whatever buffer happened to be
+  ;; current when output arrived, not the process's own buffer.  We must
+  ;; therefore resolve the expected Claude buffer name relative to the
+  ;; process buffer, whose `default-directory' is the project root.
+  ;; Otherwise `claude-code-buffer-name' evaluates `projectile-project-root'
+  ;; against the ambient buffer and signals a `user-error' whenever that
+  ;; buffer is outside a project, flooding *Messages* (see issue #17).
   (if (or (not (stringp input))
           (not claude-code-vterm-buffer-multiline-output)
-          (not (equal (claude-code-buffer-name)
+          (not (equal (when-let* ((proc-buffer (process-buffer process))
+                                  ((buffer-live-p proc-buffer)))
+                        (with-current-buffer proc-buffer
+                          (ignore-errors (claude-code-buffer-name))))
                       (buffer-name (process-buffer process)))))
       ;; Feature disabled or not a Claude buffer, pass through normally
       (funcall orig-fun process input)


### PR DESCRIPTION
## Summary

Fixes #17.

The vterm process filter installed by `claude-code-vterm-mode` runs with whatever buffer happened to be current when Claude's output arrived — **not** the process's own buffer. Its guard evaluated `claude-code-buffer-name`, which derives the name from `projectile-project-root` against that *ambient* buffer.

When the ambient buffer is outside a projectile project (e.g. `*scratch*`, `*Messages*`, a dired of a non-repo directory), `projectile-project-root` returns `nil`, `claude-code-buffer-name` signals a `user-error`, and the outer `condition-case` reports it — once per output chunk. Because Claude streams output continuously, `*Messages*` floods with tens of thousands of:

```
Error in Claude Code vterm filter: (user-error "Current directory is not part of a project") [N times]
```

## Fix

Resolve the expected buffer name relative to the **process buffer**, whose `default-directory` is set to the project root at launch (`claude-code-run`), so `projectile-project-root` resolves correctly. The lookup is additionally wrapped in `ignore-errors` so the hot path can never signal, and guarded with `buffer-live-p`.

```elisp
(not (equal (when-let* ((proc-buffer (process-buffer process))
                        ((buffer-live-p proc-buffer)))
              (with-current-buffer proc-buffer
                (ignore-errors (claude-code-buffer-name))))
            (buffer-name (process-buffer process))))
```

## Testing

Added a regression test (`test-claude-code--vterm-multiline-buffer-filter-ambient-buffer-not-in-project`) that runs the filter from a non-project ambient buffer while the process buffer is the Claude session buffer, asserting the filter passes input through without signaling. The test fails against the current code and passes with the fix.

All 116 tests pass (`make test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)