### PR TITLE
fix: keep trailing slash on Claude buffer default-directory

### DIFF
--- a/claude-code-core-test.el
+++ b/claude-code-core-test.el
@@ -65,12 +65,17 @@
            (created-buffer-name nil)
            (vterm-shell-value nil)
            (vterm-mode-called nil)
+           (captured-default-directory nil)
            (test-buffer (generate-new-buffer "*test-buffer*")))
       (unwind-protect
           (cl-letf* (((symbol-function 'get-buffer-create)
                       (lambda (name)
                         (setq buffer-created t)
                         (setq created-buffer-name name)
+                        ;; A real `get-buffer-create' gives the new buffer the
+                        ;; current `default-directory'; capture it here to
+                        ;; verify what the Claude buffer would inherit.
+                        (setq captured-default-directory default-directory)
                         ;; Simulate vterm buffer
                         (with-current-buffer test-buffer
                           (setq-local major-mode 'vterm-mode)
@@ -94,7 +99,12 @@
             (should buffer-created)
             (should buffer-switched)
             (should (string-match-p "\\*claude:" created-buffer-name))
-            (should vterm-mode-called))
+            (should vterm-mode-called)
+            ;; `default-directory' must keep its trailing slash so commands run
+            ;; from the Claude buffer (find-file, compile, ...) resolve paths
+            ;; against the project root correctly.
+            (should captured-default-directory)
+            (should (directory-name-p captured-default-directory)))
         (kill-buffer test-buffer)))))
 
 (ert-deftest test-claude-code-run-with-options ()

--- a/claude-code-core.el
+++ b/claude-code-core.el
@@ -104,7 +104,7 @@ With prefix argument, select from available options."
   (interactive)
   (let* ((buffer-name (claude-code-buffer-name))
          (project-root (claude-code-normalize-project-root (projectile-project-root)))
-         (default-directory project-root)
+         (default-directory (file-name-as-directory project-root))
          (buf (get-buffer-create buffer-name))
          (selected-option (when current-prefix-arg
                             (let* ((choices (mapcar (lambda (opt)


### PR DESCRIPTION
## Problem

Opening `find-file` (`C-x C-f`), `compile`, `dired`, etc. from the Claude vterm buffer starts from a path with **no trailing slash** (e.g. `~/src/foo/main` instead of `~/src/foo/main/`), violating the Emacs convention that `default-directory` always ends in a slash.

## Root cause

`claude-code-run` binds the buffer's `default-directory` to the *normalized* project root:

```elisp
(project-root (claude-code-normalize-project-root (projectile-project-root)))
(default-directory project-root)
```

and `claude-code-normalize-project-root` deliberately strips the trailing slash via `directory-file-name`. That stripping is correct for the normalizer's other callers (buffer names, MCP connection hash-table keys), but wrong to feed straight into `default-directory`.

## Fix

Restore the slash at the binding site only, leaving the shared normalizer untouched:

```elisp
(default-directory (file-name-as-directory project-root))
```

## Test

Extended `test-claude-code-run` to capture the `default-directory` the Claude buffer inherits (at `get-buffer-create` time) and assert it satisfies `directory-name-p`.

Full suite passes (`emacs -batch -l run-tests.el`): 115 tests, 0 unexpected.

Closes #19