### PR TITLE
fix: keep checkout ahead of installed package in run-tests.el

### DIFF
--- a/run-tests.el
+++ b/run-tests.el
@@ -14,6 +14,13 @@
 (require 'package)
 (package-initialize)
 
+;; `package-initialize' prepends installed package directories to
+;; `load-path', so an elpa-installed claude-code would shadow this
+;; checkout and the suite would silently run against stale code.
+;; Re-prepend the checkout so it always wins.
+(let ((here (file-name-directory load-file-name)))
+  (setq load-path (cons here (delete here load-path))))
+
 ;; Load all modules
 (require 'claude-code)
 


### PR DESCRIPTION
## Summary

Guards the test runner against the gotcha @waterson flagged in a comment on #18: `run-tests.el` prepends the working directory to `load-path` **before** calling `package-initialize`, but activation of an elpa-installed `claude-code` prepends the package directory via its autoloads — ending up *ahead* of the checkout. The suite then silently runs against the installed (possibly stale, byte-compiled) copy, so local edits and new tests appear to have no effect.

## Fix

Re-prepend the checkout directory after `package-initialize`, so the working tree always wins regardless of what is installed.

## Verification

Reproduced the shadowing with a synthetic elpa package (`claude-code-0.0.1` with realistic autoloads that `add-to-list` their own directory):

- Without the guard: `(locate-library "claude-code")` resolves to the installed copy
- With the guard: it resolves to the checkout, and the full suite runs green (116 tests) even with the synthetic package activated

CI is unaffected either way (no installed package there); this only hardens local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)