### PR TITLE
fix: repair events test structure and the failures it was hiding

### DIFF
--- a/claude-code-mcp-events-test.el
+++ b/claude-code-mcp-events-test.el
@@ -86,7 +86,7 @@
               ;; Should only include buffer from the target project
               (should (= 1 (length buffers)))
               (let ((file-paths (mapcar (lambda (b) (cdr (assoc 'path b))) buffers)))
-                (should (equal "/test/project/file1.el" (car file-paths))))))))))
+                (should (equal "/test/project/file1.el" (car file-paths)))))))))))
 
 ;; Buffer content change tests
 (ert-deftest test-mcp-content-change-event ()
@@ -147,7 +147,7 @@
               ;; Verify both changes are included
               (let ((files (mapcar (lambda (c) (cdr (assoc 'file c))) changes)))
                 (should (member "/test/project/file1.el" files))
-                (should (member "/test/project/file2.el" files)))))))))))
+                (should (member "/test/project/file2.el" files))))))))))
 
 (ert-deftest test-mcp-content-change-merge ()
   "Test that overlapping changes are merged."
@@ -174,7 +174,7 @@
             (let ((change (car changes)))
               ;; Should merge to cover lines 2-4
               (should (= (cdr (assoc 'startLine change)) 2))
-              (should (= (cdr (assoc 'endLine change)) 4)))))))
+              (should (= (cdr (assoc 'endLine change)) 4)))))))))
 
 ;; Diagnostics change tests
 (ert-deftest test-mcp-diagnostics-event ()
@@ -184,36 +184,29 @@
       (let ((claude-code-mcp-project-connections (make-hash-table :test 'equal)))
         (puthash "/test/project" t claude-code-mcp-project-connections)
 
-        ;; Mock LSP diagnostics
-        (cl-letf (((symbol-function 'fboundp)
-                   (lambda (sym)
-                     (or (eq sym 'lsp-diagnostics)
-                         (eq sym 'lsp:diagnostic-message)
-                         (eq sym 'lsp:position-character)
-                         (eq sym 'lsp:range-start)
-                         (eq sym 'lsp:diagnostic-range)
-                         (eq sym 'lsp:diagnostic-severity))))
-                  ((symbol-function 'lsp-diagnostics)
+        ;; Mock LSP diagnostics.  `lsp-diagnostics' returns a hash table
+        ;; of file -> list of diagnostic objects, which is what
+        ;; `claude-code-mcp-events-send-diagnostics-update' consumes.
+        (cl-letf (((symbol-function 'lsp-diagnostics)
                    (lambda ()
                      (let ((diags (make-hash-table :test 'equal)))
                        (puthash "/test/project/file.el"
-                                (let ((line-diags (make-hash-table :test 'equal)))
-                                  (puthash 1 (list (list :message "Test error"
-                                                         :severity 1
-                                                         :range (list :start (list :line 0 :character 0)
-                                                                      :end (list :line 0 :character 5))))
-                                           line-diags)
-                                  line-diags)
+                                (list (list :message "Test error"
+                                            :severity 1
+                                            :range (list :start (list :line 0 :character 0)
+                                                         :end (list :line 0 :character 5))))
                                 diags)
                        diags)))
                   ((symbol-function 'lsp:diagnostic-message)
                    (lambda (diag) (plist-get diag :message)))
-                  ((symbol-function 'lsp:diagnostic-severity)
+                  ((symbol-function 'lsp:diagnostic-severity?)
                    (lambda (diag) (plist-get diag :severity)))
                   ((symbol-function 'lsp:diagnostic-range)
                    (lambda (diag) (plist-get diag :range)))
                   ((symbol-function 'lsp:range-start)
                    (lambda (range) (plist-get range :start)))
+                  ((symbol-function 'lsp:position-line)
+                   (lambda (pos) (plist-get pos :line)))
                   ((symbol-function 'lsp:position-character)
                    (lambda (pos) (plist-get pos :character)))
                   ((symbol-function 'find-buffer-visiting)
@@ -244,29 +237,32 @@
       (puthash "/project1" t claude-code-mcp-project-connections)
       (puthash "/project2" t claude-code-mcp-project-connections)
 
-      ;; Mock LSP diagnostics for multiple files
-      (cl-letf (((symbol-function 'fboundp)
-                 (lambda (sym)
-                   (or (eq sym 'lsp-diagnostics)
-                       (eq sym 'lsp:diagnostic-message))))
-                ((symbol-function 'lsp-diagnostics)
+      ;; Mock LSP diagnostics for multiple files.  `lsp-diagnostics'
+      ;; returns a hash table of file -> list of diagnostic objects.
+      (cl-letf (((symbol-function 'lsp-diagnostics)
                  (lambda ()
                    (let ((diags (make-hash-table :test 'equal)))
                      (puthash "/project1/file.el"
-                              (let ((line-diags (make-hash-table :test 'equal)))
-                                (puthash 1 (list (list :message "Error in project1"))
-                                         line-diags)
-                                line-diags)
+                              (list (list :message "Error in project1"
+                                          :range (list :start (list :line 0 :character 0))))
                               diags)
                      (puthash "/project2/file.el"
-                              (let ((line-diags (make-hash-table :test 'equal)))
-                                (puthash 1 (list (list :message "Error in project2"))
-                                         line-diags)
-                                line-diags)
+                              (list (list :message "Error in project2"
+                                          :range (list :start (list :line 0 :character 0))))
                               diags)
                      diags)))
                 ((symbol-function 'lsp:diagnostic-message)
                  (lambda (diag) (plist-get diag :message)))
+                ((symbol-function 'lsp:diagnostic-severity?)
+                 (lambda (diag) (plist-get diag :severity)))
+                ((symbol-function 'lsp:diagnostic-range)
+                 (lambda (diag) (plist-get diag :range)))
+                ((symbol-function 'lsp:range-start)
+                 (lambda (range) (plist-get range :start)))
+                ((symbol-function 'lsp:position-line)
+                 (lambda (pos) (plist-get pos :line)))
+                ((symbol-function 'lsp:position-character)
+                 (lambda (pos) (plist-get pos :character)))
                 ((symbol-function 'find-buffer-visiting)
                  (lambda (file)
                    (with-current-buffer (get-buffer-create file)
@@ -289,7 +285,7 @@
                                   (plist-get msg :project))
                                 test-mcp-sent-messages)))
           (should (member "/project1" projects))
-          (should (member "/project2" projects))))))
+          (should (member "/project2" projects)))))
     ;; Cleanup test buffers
     (dolist (buf '("/project1/file.el" "/project2/file.el"))
       (when (get-buffer buf)
@@ -336,7 +332,7 @@
             (should (member "bufferContentModified" events)))
 
           ;; Disable events
-          (claude-code-mcp-events-disable)))))))
+          (claude-code-mcp-events-disable))))))
 
 (ert-deftest test-mcp-event-debouncing ()
   "Test that event debouncing works correctly."

--- a/claude-code-mcp-events.el
+++ b/claude-code-mcp-events.el
@@ -131,7 +131,12 @@ OLD-LEN is the length of the text before the change."
         ;; Store change information
         (let* ((file (buffer-file-name))
                (start-line (line-number-at-pos beg))
-               (end-line (line-number-at-pos end))
+               ;; END is the position after the changed text, so when the
+               ;; change ends exactly at a line boundary, END sits on the
+               ;; next (untouched) line.  Report the line of the last
+               ;; changed character instead; `max' keeps pure deletions
+               ;; (BEG = END) on the line of BEG.
+               (end-line (line-number-at-pos (max beg (1- end))))
                (existing (assoc file claude-code-mcp-events-pending-changes)))
 
           (if existing


### PR DESCRIPTION
## Summary

While adding a test to `claude-code-mcp-events-test.el` I noticed it silently never ran. Digging in: **5 of the 9 `ert-deftest` forms in the file were nested inside preceding tests** due to unbalanced parentheses — one missing closer at the end of one test, compensated by an extra closer at the end of a later one (this pattern occurred twice). `check-parens` passes because the file as a whole is balanced, but only 4 tests were defined at top level. The other 5 (`content-change-event`, `content-change-batching`, `diagnostics-event`, `diagnostics-batching`, `event-system-integration`) have never run — locally or in CI.

## Changes

1. **Repair the structure** (4 one-paren edits) so all 9 tests are top-level and actually run.
2. **Fix the three latent failures the repair revealed:**
   - `content-change-event` (real bug in `claude-code-mcp-events.el`): `after-change` reported `endLine` one line too far when a change ends exactly at a line boundary, because `END` is the position *after* the changed text. Now reports the line of the last changed character — `(max beg (1- end))`, which also keeps pure deletions (`BEG = END`) on the line of `BEG`.
   - `diagnostics-event` / `diagnostics-batching` (test bugs): the mocks modeled `lsp-diagnostics` as file → hash of line → diags, but the implementation consumes file → **list** of diagnostics, and calls `lsp:position-line` / `lsp:diagnostic-severity?`, which weren't mocked at all. Mocks now match the real interface.

## Tests

Full suite: **122 tests green** (117 previously visible + the 5 revealed ones).

## Note

A follow-up PR (stacked on this branch) fixes a project-boundary matching bug that one of my new tests needed this repair to even register for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)