### PR TITLE
fix: land project boundary matching fix on master

### DIFF
--- a/claude-code-mcp-events-test.el
+++ b/claude-code-mcp-events-test.el
@@ -88,6 +88,26 @@
               (let ((file-paths (mapcar (lambda (b) (cdr (assoc 'path b))) buffers)))
                 (should (equal "/test/project/file1.el" (car file-paths)))))))))))
 
+(ert-deftest test-mcp-buffer-list-excludes-sibling-prefix-project ()
+  "Buffers of a sibling project sharing a name prefix are excluded.
+The connection key is the root without a trailing slash, so a plain
+`string-prefix-p' would also match \"/test/project2/...\" against the
+root \"/test/project\".  The boundary must be a full directory."
+  (with-mcp-message-capture
+    (with-mock-project-root "/test/project"
+      (let ((claude-code-mcp-project-connections (make-hash-table :test 'equal)))
+        (puthash "/test/project" t claude-code-mcp-project-connections)
+
+        (with-test-buffer "/test/project/file1.el" "content1"
+          (with-test-buffer "/test/project2/file2.el" "content2"
+            (claude-code-mcp-events-send-buffer-list-update)
+
+            (let* ((msg (car test-mcp-sent-messages))
+                   (file-paths (mapcar (lambda (b) (cdr (assoc 'path b)))
+                                       (cdr (assoc 'buffers (plist-get msg :params))))))
+              (should (member "/test/project/file1.el" file-paths))
+              (should-not (member "/test/project2/file2.el" file-paths)))))))))
+
 ;; Buffer content change tests
 (ert-deftest test-mcp-content-change-event ()
   "Test buffer content change event."

--- a/claude-code-mcp-events.el
+++ b/claude-code-mcp-events.el
@@ -98,8 +98,10 @@
            (dolist (buffer (buffer-list))
              (let ((file-path (buffer-file-name buffer))
                    (buffer-name (buffer-name buffer)))
+               ;; Compare against the slash-terminated root so a sibling
+               ;; project like "<root>2/..." does not match.
                (when (and file-path
-                          (string-prefix-p project-root file-path)
+                          (string-prefix-p (file-name-as-directory project-root) file-path)
                           (not (string-prefix-p " " buffer-name)))
                  (push `((path . ,file-path)
                          (name . ,buffer-name)
@@ -127,7 +129,8 @@ OLD-LEN is the length of the text before the change."
              (buffer-file-name))
     (let ((project-root (ignore-errors (claude-code-normalize-project-root (projectile-project-root)))))
       (when (and project-root
-                 (string-prefix-p project-root (buffer-file-name)))
+                 (string-prefix-p (file-name-as-directory project-root)
+                                  (buffer-file-name)))
         ;; Store change information
         (let* ((file (buffer-file-name))
                (start-line (line-number-at-pos beg))

--- a/claude-code-mcp-tools-test.el
+++ b/claude-code-mcp-tools-test.el
@@ -43,6 +43,29 @@
                   (should (assoc 'modified buffer-info))))))
         (kill-buffer test-buffer)))))
 
+(ert-deftest test-mcp-handle-getOpenBuffers-excludes-sibling-prefix-project ()
+  "Buffers of a sibling project sharing a name prefix are excluded.
+The project root is compared without a trailing slash, so a plain
+`string-prefix-p' would also match \"/test/project2/...\" against the
+root \"/test/project\".  The boundary must be a full directory."
+  (cl-letf (((symbol-function 'projectile-project-root)
+             (lambda () "/test/project/")))
+    (let ((inside-buffer (generate-new-buffer "inside.el"))
+          (sibling-buffer (generate-new-buffer "sibling.el")))
+      (unwind-protect
+          (progn
+            (with-current-buffer inside-buffer
+              (setq buffer-file-name "/test/project/inside.el"))
+            (with-current-buffer sibling-buffer
+              (setq buffer-file-name "/test/project2/sibling.el"))
+            (let* ((result (claude-code-mcp-handle-getOpenBuffers '((includeHidden . nil))))
+                   (paths (mapcar (lambda (b) (cdr (assoc 'path b)))
+                                  (cdr (assoc 'buffers result)))))
+              (should (member "/test/project/inside.el" paths))
+              (should-not (member "/test/project2/sibling.el" paths))))
+        (kill-buffer inside-buffer)
+        (kill-buffer sibling-buffer)))))
+
 (ert-deftest test-mcp-handle-getCurrentSelection ()
   "Test getCurrentSelection handler."
   (with-temp-buffer

--- a/claude-code-mcp-tools.el
+++ b/claude-code-mcp-tools.el
@@ -83,8 +83,10 @@ See `display-buffer' for the format of this value."
     (dolist (buffer (buffer-list))
       (let ((file-path (buffer-file-name buffer))
             (buffer-name (buffer-name buffer)))
+        ;; Compare against the slash-terminated root so a sibling
+        ;; project like "<root>2/..." does not match.
         (when (and file-path
-                   (string-prefix-p project-root file-path)
+                   (string-prefix-p (file-name-as-directory project-root) file-path)
                    (or include-hidden
                        (not (string-prefix-p " " buffer-name))))
           (push `((path . ,file-path)


### PR DESCRIPTION
## Summary

#25 (project boundary matching fix) was stacked on the `fix/events-test-structure` branch, and got merged into that base branch rather than `master` — while #24 merged the branch's earlier state into `master`. As a result the boundary fix never reached `master`.

This PR carries the remaining delta (the already-reviewed #25 content, unchanged) onto `master`:

- Compare file paths against the slash-terminated project root at the three filtering sites (events buffer-list, after-change guard, `getOpenBuffers`), so `/tmp/proj2`'s files no longer leak into `/tmp/proj`'s results
- Two regression tests for the sibling-prefix case

🤖 Generated with [Claude Code](https://claude.com/claude-code)